### PR TITLE
Add jpegrescan support

### DIFF
--- a/lib/image_optim/worker/jpegtran.rb
+++ b/lib/image_optim/worker/jpegtran.rb
@@ -11,15 +11,27 @@ class ImageOptim
 
     private
 
+      def has_jpegrescan
+        system("which -s jpegrescan")
+      end
+
+      def default_bin
+        has_jpegrescan ? 'jpegrescan' : super
+      end
+
       def parse_options(options)
         get_option!(options, :copy, false){ |v| !!v }
         get_option!(options, :progressive, true){ |v| !!v }
       end
 
       def command_args(src, dst)
-        args = %W[-optimize -outfile #{dst} #{src}]
-        args.unshift '-copy', copy ? 'all' : 'none'
-        args.unshift '-progressive' if progressive
+        if has_jpegrescan
+          args = %W[#{src} #{dst}]
+        else
+          args = %W[-optimize -outfile #{dst} #{src}]
+          args.unshift '-copy', copy ? 'all' : 'none'
+          args.unshift '-progressive' if progressive
+        end
         args
       end
     end


### PR DESCRIPTION
image_optim doesn't optimise jpegs as well as ImageOptim.app. After routing through each, I discovered that this gem is lacking JPEGrescan support.

After adding this, my image_optim output appears to exactly match that of the desktop app, with the example image I've been testing going from a 0.30% to 6.49% reduction.

JPEGrescan works as a layer over the top of jpegtran, and I've included it in the jpegtran worker (in the same style as http://code.google.com/p/imageoptim/source/browse/trunk/imageoptim/Workers/JpegtranWorker.m). I think this is the best way to provide support without duplicating execution of jpegtran.

More on JPEGrescan: http://news.ycombinator.com/item?id=803839
