### PR TITLE
Fix which command on ubuntu

### DIFF
--- a/lib/image_optim.rb
+++ b/lib/image_optim.rb
@@ -175,9 +175,9 @@ class ImageOptim
           symlink.make_symlink(File.expand_path(path))
           at_exit{ symlink.unlink }
 
-          @resolved_bins[bin] = system(*%W[which -s #{symlink}])
+          @resolved_bins[bin] = system(*%W[which #{symlink} > /dev/null])
         else
-          @resolved_bins[bin] = system(*%W[which -s #{bin}])
+          @resolved_bins[bin] = system(*%W[which #{bin} > /dev/null])
         end
       end
     end

--- a/spec/image_optim_spec.rb
+++ b/spec/image_optim_spec.rb
@@ -196,7 +196,7 @@ describe ImageOptim do
     it "should resolve bin in path" do
       with_env 'LS_BIN', nil do
         image_optim = ImageOptim.new
-        image_optim.should_receive(:system).with(*%w[which -s ls]).once.and_return(true)
+        image_optim.should_receive(:system).with(*%w[which ls > /dev/null]).once.and_return(true)
         FSPath.should_not_receive(:temp_dir)
 
         5.times do
@@ -212,7 +212,7 @@ describe ImageOptim do
         symlink = stub(:symlink)
 
         image_optim = ImageOptim.new
-        image_optim.should_receive(:system).with(*%W[which -s #{symlink}]).once.and_return(true)
+        image_optim.should_receive(:system).with(*%W[which #{symlink} > /dev/null]).once.and_return(true)
         FSPath.should_receive(:temp_dir).once.and_return(tmpdir)
         tmpdir.should_receive(:/).with(:image_optim).once.and_return(symlink)
         symlink.should_receive(:make_symlink).with(File.expand_path(path)).once
@@ -235,7 +235,7 @@ describe ImageOptim do
     it "should raise on failure to resolve bin" do
       with_env 'SHOULD_NOT_EXIST_BIN', nil do
         image_optim = ImageOptim.new
-        image_optim.should_receive(:system).with(*%w[which -s should_not_exist]).once.and_return(false)
+        image_optim.should_receive(:system).with(*%w[which should_not_exist > /dev/null]).once.and_return(false)
         FSPath.should_not_receive(:temp_dir)
 
         5.times do
@@ -253,7 +253,7 @@ describe ImageOptim do
         symlink = stub(:symlink)
 
         image_optim = ImageOptim.new
-        image_optim.should_receive(:system).with(*%W[which -s #{symlink}]).once.and_return(false)
+        image_optim.should_receive(:system).with(*%W[which #{symlink} > /dev/null]).once.and_return(false)
         FSPath.should_receive(:temp_dir).once.and_return(tmpdir)
         tmpdir.should_receive(:/).with(:should_not_exist).once.and_return(symlink)
         symlink.should_receive(:make_symlink).with(File.expand_path(path)).once


### PR DESCRIPTION
Hi, the 'which' command has no option '-s' on my system (ubuntu 12.10). which makes the command fail and return a bad exit status. I figured just redirecting the output to /dev/null would fix this issue for me while remaining compatible with OSX.
