### PR TITLE
Read options from Rails app configuration in Railtie

### DIFF
--- a/lib/image_optim/railtie.rb
+++ b/lib/image_optim/railtie.rb
@@ -4,7 +4,11 @@ class ImageOptim
   class Railtie < Rails::Railtie
     initializer 'image_optim.initializer' do |app|
       if app.config.assets.compress && app.config.assets.image_optim != false
-        image_optim = ImageOptim.new(app.config.assets.image_optim || {})
+        image_optim = if app.config.assets.image_optim == true
+                        ImageOptim.new
+                      else
+                        ImageOptim.new(app.config.assets.image_optim || {})
+                      end
 
         processor = proc do |context, data|
           image_optim.optimize_image_data(data) || data


### PR DESCRIPTION
I wanted to disable pngout for the asset pipeline in a particular Rails env, but there wasn't a good way (from the app repo) to do this. It seemed sensible to allow settings at the app or env level so I could do something like:

``` ruby
config.assets.image_optim = { pngout: false }
```

Also allows for simple case of:

``` ruby
config.assets.image_optim = true
```
