### PR TITLE
Update image_size 1.2.0 -> 1.3.0

### DIFF
--- a/image_optim.gemspec
+++ b/image_optim.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency 'fspath', '~> 2.1.0'
-  s.add_dependency 'image_size', '~> 1.2.0'
+  s.add_dependency 'image_size', '~> 1.3.0'
   s.add_dependency 'exifr', '~> 1.1.3'
   s.add_dependency 'progress', '~> 3.0.0'
   s.add_dependency 'in_threads', '~> 1.2.0'

--- a/lib/image_optim/image_meta.rb
+++ b/lib/image_optim/image_meta.rb
@@ -5,14 +5,14 @@ class ImageOptim
     def self.for_path(path)
       is = ImageSize.path(path)
       new(is.format)
-    rescue => e
+    rescue ImageSize::FormatError => e
       warn "#{e} (detecting format of image at #{path})"
     end
 
     def self.for_data(data)
       is = ImageSize.new(data)
       new(is.format)
-    rescue => e
+    rescue ImageSize::FormatError => e
       warn "#{e} (detecting format of image data)"
     end
 


### PR DESCRIPTION
The only new thing in this version is that image_size will raise
FormatError instead of RuntimeError[1](https://github.com/toy/image_size/commit/8dfeab767ffd83f4b0e965886ef8310eee19ea2d). We can then rescue this
explicitly when using ImageSize.
