### PR TITLE
Added -strip option to optipng

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@
 
 * Add tests for railtie, also to prevent [issues like #72](https://github.com/toy/image_optim/issues/72) [#73](https://github.com/toy/image_optim/issues/73) [@toy](https://github.com/toy)
 * Remove haml development dependency [@toy](https://github.com/toy)
+* Add `-strip` option to optipng worker to remove all metadata chunks, on by default [@jwidderich](https://github.com/jwidderich)
 
 ## v0.20.2 (2014-12-26)
 

--- a/README.markdown
+++ b/README.markdown
@@ -303,6 +303,7 @@ Worker has no options
 ### :optipng =>
 * `:level` — Optimization level preset: `0` is least, `7` is best *(defaults to `6`)*
 * `:interlace` — Interlace: `true` - interlace on, `false` - interlace off, `nil` - as is in original image *(defaults to `false`)*
+* `:strip` — Remove all auxiliary chunks *(defaults to `true`)*
 
 ### :pngcrush =>
 * `:chunks` — List of chunks to remove or `:alla` - all except tRNS/transparency or `:allb` - all except tRNS and gAMA/gamma *(defaults to `:alla`)*

--- a/lib/image_optim/worker/optipng.rb
+++ b/lib/image_optim/worker/optipng.rb
@@ -21,6 +21,9 @@ class ImageOptim
         TrueFalseNil.convert(v)
       end
 
+      STRIP_OPTION =
+      option(:strip, true, 'Remove all auxiliary chunks'){ |v| !!v }
+
       def optimize(src, dst)
         src.copy(dst)
         args = %W[
@@ -30,6 +33,10 @@ class ImageOptim
           #{dst}
         ]
         args.unshift "-i#{interlace ? 1 : 0}" unless interlace.nil?
+        if strip
+          args.unshift 'all'
+          args.unshift '-strip'
+        end
         execute(:optipng, *args) && optimized?(src, dst)
       end
     end


### PR DESCRIPTION
Support the auxiliary chunk stripping option of optipng. Disabled by default. You can either pass a list of png chunknames or :all.