### PR TITLE
added compression methods option for passing to jpeg-compress

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Use quality `0..100` by default in lossy mode of pngquant worker [#77](https://github.com/toy/image_optim/issues/77) [@toy](https://github.com/toy)
+* Add `method` option for jpegrecompress, default to `ssim`[#103](https://github.com/toy/image_optim/pull/103)
 
 ## v0.21.0 (2015-05-30)
 

--- a/lib/image_optim/runner/option_parser.rb
+++ b/lib/image_optim/runner/option_parser.rb
@@ -185,6 +185,8 @@ ImageOptim::Runner::OptionParser::DEFINE = proc do |op, options|
         [Integer, 'N']
       when Array >= type
         [Array, 'a,b,c']
+      when String >= type
+        [String, 'S']
       when ImageOptim::NonNegativeIntegerRange == type
         [type, 'M-N']
       else

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -21,6 +21,10 @@ class ImageOptim
         OptionHelpers.limit_with_range(v.to_i, 0...QUALITY_NAMES.length)
       end
 
+      METHOD_NAMES = [:mpe, :ssim, :'ms-ssim', :smallfry]
+
+      METHOD_OPTION = option(:method, :ssim, Array, "Compression method: #{METHOD_NAMES.join(', ')}")
+
       def used_bins
         [:'jpeg-recompress']
       end
@@ -33,6 +37,7 @@ class ImageOptim
       def optimize(src, dst)
         args = %W[
           --quality #{QUALITY_NAMES[quality]}
+          --method #{method.first}
           --no-copy
           #{src}
           #{dst}

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -17,14 +17,20 @@ class ImageOptim
       end.join(', ')
 
       QUALITY_OPTION =
-      option(:quality, 3, "JPEG quality preset: #{quality_names_desc}") do |v|
-        OptionHelpers.limit_with_range(v.to_i, 0...QUALITY_NAMES.length)
+        option(:quality, 3, "JPEG quality preset: #{quality_names_desc}") do |v|
+          OptionHelpers.limit_with_range(v.to_i, 0...QUALITY_NAMES.length)
+        end
+
+      METHOD_OPTION = option(:method, 'ssim', 'Compression method: '\
+          '`mpe` - Mean pixel error, '\
+          '`ssim` - Structural similarity, '\
+          '`ms-ssim` - Multi-scale structural similarity (slow!), '\
+          '`smallfry` - Linear-weighted BBCQ-like (may be patented)') do |v|
+        unless %w[mpe ssim ms-ssim smallfry].include? v
+          warn "Unknown method for jpegrecompress: #{v}"
+        end
+        v
       end
-
-      METHOD_NAMES = [:mpe, :ssim, :'ms-ssim', :smallfry]
-
-      METHOD_OPTION = option(:method, 'ssim',
-                             "Compression method: #{METHOD_NAMES.join(', ')}")
 
       def used_bins
         [:'jpeg-recompress']

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -23,7 +23,8 @@ class ImageOptim
 
       METHOD_NAMES = [:mpe, :ssim, :'ms-ssim', :smallfry]
 
-      METHOD_OPTION = option(:method, :ssim, Array, "Compression method: #{METHOD_NAMES.join(', ')}")
+      METHOD_OPTION = option(:method, 'ssim',
+                             "Compression method: #{METHOD_NAMES.join(', ')}")
 
       def used_bins
         [:'jpeg-recompress']
@@ -37,7 +38,7 @@ class ImageOptim
       def optimize(src, dst)
         args = %W[
           --quality #{QUALITY_NAMES[quality]}
-          --method #{method.first}
+          --method #{method}
           --no-copy
           #{src}
           #{dst}


### PR DESCRIPTION
I added the option to select the compression method, with the same ssim default. Didn't want to introduce many changes, so I opted for the `Array` type option and grabbed the first one, since there wasn't a `String` option and didn't want to map the methods with numbers

Let me know!
