### PR TITLE
Run image compress even if Rails.application.assets is nil

### DIFF
--- a/lib/image_optim/railtie.rb
+++ b/lib/image_optim/railtie.rb
@@ -21,7 +21,11 @@ class ImageOptim
       return if app.config.assets.compress == false
       return if app.config.assets.image_optim == false
 
-      app.assets
+      if defined?(Sprockets::Rails) && Gem::Version.new(Sprockets::Rails::VERSION) >= Gem::Version.new("3.0.0")
+        true
+      else
+        app.assets
+      end
     end
 
     def options(app)
@@ -39,10 +43,20 @@ class ImageOptim
         image_optim.optimize_image_data(data) || data
       end
 
-      app.assets.register_preprocessor 'image/gif', :image_optim, &processor
-      app.assets.register_preprocessor 'image/jpeg', :image_optim, &processor
-      app.assets.register_preprocessor 'image/png', :image_optim, &processor
-      app.assets.register_preprocessor 'image/svg+xml', :image_optim, &processor
+      if Gem::Version.new(Sprockets::Rails::VERSION) >= Gem::Version.new("3.0.0")
+        app.config.assets.configure do |env|
+          env.register_preprocessor 'image/gif', :image_optim, &processor
+          env.register_preprocessor 'image/jpeg', :image_optim, &processor
+          env.register_preprocessor 'image/png', :image_optim, &processor
+          env.register_preprocessor 'image/svg+xml', :image_optim, &processor
+        end
+      else
+        app.assets.register_preprocessor 'image/gif', :image_optim, &processor
+        app.assets.register_preprocessor 'image/jpeg', :image_optim, &processor
+        app.assets.register_preprocessor 'image/png', :image_optim, &processor
+        app.assets.register_preprocessor 'image/svg+xml', :image_optim, &processor
+      end
+
     end
   end
 end

--- a/lib/image_optim/railtie.rb
+++ b/lib/image_optim/railtie.rb
@@ -43,7 +43,7 @@ class ImageOptim
         image_optim.optimize_image_data(data) || data
       end
 
-      if Gem::Version.new(Sprockets::Rails::VERSION) >= Gem::Version.new("3.0.0")
+      if defined?(Sprockets::Rails) && Gem::Version.new(Sprockets::Rails::VERSION) >= Gem::Version.new("3.0.0")
         app.config.assets.configure do |env|
           env.register_preprocessor 'image/gif', :image_optim, &processor
           env.register_preprocessor 'image/jpeg', :image_optim, &processor


### PR DESCRIPTION
Since https://github.com/rails/sprockets-rails/commit/d7c7ee19991c565eb77ee143be2d009ba4472122#diff-b295f4f07d2e863f15e53eb2047cfd1f we can't rely on app.assets for register_preprocessor

When compile=false and we precompile assets 
  register_preprocessor?(app) method will always return false