### PR TITLE
Run image compress even if Rails.application.assets is nil

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,11 @@ Style/SpaceBeforeBlockBraces:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma
-Style/TrailingCommaInLiteral:
+Style/AlignParameters:
+  EnforcedStyle: with_first_parameter
+
+#Style/TrailingCommaInArguments:
+#  EnforcedStyleForMultiline: comma
+#Style/TrailingCommaInLiteral:
+Style/TrailingComma:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,5 +62,7 @@ Style/SpaceBeforeBlockBraces:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/image_optim.gemspec
+++ b/image_optim.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'image_optim_pack', '~> 0.2'
   s.add_development_dependency 'rspec', '~> 3.0'
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3')
-    s.add_development_dependency 'rubocop', '~> 0.35'
+    s.add_development_dependency 'rubocop', '0.35'
   end
 end

--- a/lib/image_optim/image_optim_processor.rb
+++ b/lib/image_optim/image_optim_processor.rb
@@ -1,14 +1,13 @@
-#require 'sprockets/processor'
 class ImageOptim
+  # Adds image_optim_processor as class to avoid LegacyTildPreprocessor
+  # in sprockets
+  class ImageOptimProcessor
+    def self.opti_images_options=(options)
+      @options = options == true ? {} : (options || {})
+      image_optim
+    end
 
-class ImageOptimProcessor #< Sprockets::Processor
-
-  def self.opti_images_options=( options )
-    @@options = options == true ? {} : ( options || {} )
-    image_optim
-  end
-
-  def self.call(input)
+    def self.call(input)
       @environment  = input[:environment]
       @uri          = input[:uri]
       @filename     = input[:filename]
@@ -19,25 +18,22 @@ class ImageOptimProcessor #< Sprockets::Processor
       @links        = Set.new(input[:metadata][:links])
       @dependencies = Set.new(input[:metadata][:dependencies])
 
-      data = process_source( input[:data] )
+      data = process_source(input[:data])
 
-      { data: data,
-        required: @required,
-        stubbed: @stubbed,
-        links: @links,
-        dependencies: @dependencies,
-        skip_gzip: true 
-        }
+      {:data => data,
+       :required => @required,
+       :stubbed => @stubbed,
+       :links => @links,
+       :dependencies => @dependencies,
+       :charset => nil}
+    end
+
+    def self.process_source(data)
+      image_optim.optimize_image_data(data) || data
+    end
+
+    def self.image_optim
+      @image_optim ||= ImageOptim.new(@options)
+    end
   end
-
-  def self.process_source( data )
-    result = image_optim.optimize_image_data(data) || data
-  end
-
-private
-  def self.image_optim
-    @@image_optim ||= ImageOptim.new( @@options )
-  end
-end
-
 end

--- a/lib/image_optim/image_optim_processor.rb
+++ b/lib/image_optim/image_optim_processor.rb
@@ -1,0 +1,43 @@
+#require 'sprockets/processor'
+class ImageOptim
+
+class ImageOptimProcessor #< Sprockets::Processor
+
+  def self.opti_images_options=( options )
+    @@options = options == true ? {} : ( options || {} )
+    image_optim
+  end
+
+  def self.call(input)
+      @environment  = input[:environment]
+      @uri          = input[:uri]
+      @filename     = input[:filename]
+      @dirname      = File.dirname(@filename)
+      @content_type = input[:content_type]
+      @required     = Set.new(input[:metadata][:required])
+      @stubbed      = Set.new(input[:metadata][:stubbed])
+      @links        = Set.new(input[:metadata][:links])
+      @dependencies = Set.new(input[:metadata][:dependencies])
+
+      data = process_source( input[:data] )
+
+      { data: data,
+        required: @required,
+        stubbed: @stubbed,
+        links: @links,
+        dependencies: @dependencies,
+        skip_gzip: true 
+        }
+  end
+
+  def self.process_source( data )
+    result = image_optim.optimize_image_data(data) || data
+  end
+
+private
+  def self.image_optim
+    @@image_optim ||= ImageOptim.new( @@options )
+  end
+end
+
+end

--- a/lib/image_optim/railtie.rb
+++ b/lib/image_optim/railtie.rb
@@ -1,7 +1,6 @@
 require 'image_optim'
 require 'image_optim/image_optim_processor'
 
-
 class ImageOptim
   # Adds image_optim as preprocessor for gif, jpeg, png and svg images
   class Railtie < Rails::Railtie
@@ -44,16 +43,20 @@ class ImageOptim
         app.assets.register_preprocessor 'image/gif', :image_optim, &processor
         app.assets.register_preprocessor 'image/jpeg', :image_optim, &processor
         app.assets.register_preprocessor 'image/png', :image_optim, &processor
-        app.assets.register_preprocessor 'image/svg+xml', :image_optim, &processor
+        app.assets.register_preprocessor 'image/svg+xml', :image_optim,
+                                         &processor
       else
         app.config.assets.configure do |env|
-          env.register_preprocessor 'image/gif', :image_optim, ImageOptim::ImageOptimProcessor
-          env.register_preprocessor 'image/jpeg', :image_optim, ImageOptim::ImageOptimProcessor
-          env.register_preprocessor 'image/png', :image_optim, ImageOptim::ImageOptimProcessor
-          env.register_preprocessor 'image/svg+xml', :image_optim, ImageOptimProcessor
+          env.register_preprocessor 'image/gif', :image_optim,
+                                    ImageOptim::ImageOptimProcessor
+          env.register_preprocessor 'image/jpeg', :image_optim,
+                                    ImageOptim::ImageOptimProcessor
+          env.register_preprocessor 'image/png', :image_optim,
+                                    ImageOptim::ImageOptimProcessor
+          env.register_preprocessor 'image/svg+xml', :image_optim,
+                                    ImageOptim::ImageOptimProcessor
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
Since rails/sprockets-rails@d7c7ee1#diff-b295f4f07d2e863f15e53eb2047cfd1f we can't rely on app.assets for register_preprocessor

When compile=false and we precompile assets
register_preprocessor?(app) method will always return false
