### PR TITLE
Fix an issue not working OptiPNG interlace option

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Add proper handling of `ImageOptim.respond_to?` [@toy](https://github.com/toy)
+* Fix an issue not working OptiPNG `interlace` option [#136](https://github.com/toy/image_optim/pull/136) [@mrk21](https://github.com/mrk21)
 
 ## v0.23.0 (2016-07-17)
 

--- a/lib/image_optim/worker/optipng.rb
+++ b/lib/image_optim/worker/optipng.rb
@@ -42,6 +42,10 @@ class ImageOptim
         end
         execute(:optipng, *args) && optimized?(src, dst)
       end
+
+      def optimized?(src, dst)
+        interlace ? dst.size? : super
+      end
     end
   end
 end

--- a/spec/image_optim/worker/optipng_spec.rb
+++ b/spec/image_optim/worker/optipng_spec.rb
@@ -55,4 +55,48 @@ describe ImageOptim::Worker::Optipng do
       end
     end
   end
+
+  describe '#optimized?' do
+    let(:src){ instance_double(ImageOptim::Path, src_options) }
+    let(:dst){ instance_double(ImageOptim::Path, dst_options) }
+    let(:src_options){ {:size? => 10, :size => 10} }
+    let(:dst_options){ {:size? => 9, :size => 9} }
+    let(:instance){ described_class.new(ImageOptim.new, instance_options) }
+    let(:instance_options){ {} }
+
+    subject{ instance.optimized?(src, dst) }
+
+    context 'when interlace option is enabled' do
+      let(:instance_options){ {:interlace => true} }
+
+      context 'when dst is empty' do
+        let(:dst_options){ {:size? => nil} }
+        it{ is_expected.to be_falsy }
+      end
+
+      context 'when dst is not empty' do
+        let(:dst_options){ {:size? => 20, :size => 20} }
+        it{ is_expected.to be_truthy }
+      end
+    end
+
+    context 'when interlace option is disabled' do
+      let(:instance_options){ {:interlace => false} }
+
+      context 'when dst is empty' do
+        let(:dst_options){ {:size? => nil} }
+        it{ is_expected.to be_falsy }
+      end
+
+      context 'when dst is greater than or equal to src' do
+        let(:dst_options){ {:size? => 10, :size => 10} }
+        it{ is_expected.to be_falsy }
+      end
+
+      context 'when dst is less than src' do
+        let(:dst_options){ {:size? => 9, :size => 9} }
+        it{ is_expected.to be_truthy }
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have fixed an issue not working OptiPNG worker when the `interlace` option enabled.

The reason is that the file size of an interlaced PNG is greater than the file size of a non interlaced PNG generally, so I have changed so that `optimized?` conditions for OptiPNG worker is always true if the `interlace` option is enabled.