### PR TITLE
Introduce the Guetzli JPEG encoder

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Introduce support for the [Guetzli JPEG encoder](https://research.googleblog.com/2017/03/announcing-guetzli-new-open-source-jpeg.html) [@ignisf](https://github.com/ignisf)
+
 ## v0.24.3 (2017-05-04)
 
 * Set mode of cache files to `0666 & ~umask`, related to [#147](https://github.com/toy/image_optim/issues/147) [@toy](https://github.com/toy)

--- a/README.markdown
+++ b/README.markdown
@@ -13,6 +13,7 @@ Optimize (lossless compress, optionally lossy) images (jpeg, png, gif, svg) usin
 * [advpng](http://advancemame.sourceforge.net/doc-advpng.html) from [AdvanceCOMP](http://advancemame.sourceforge.net/comp-readme.html)
 (will use [zopfli](https://code.google.com/p/zopfli/) on default/maximum level 4)
 * [gifsicle](http://www.lcdf.org/gifsicle/)
+* [guetzli](https://github.com/google/guetzli)
 * [jhead](http://www.sentex.net/~mwandel/jhead/)
 * [jpegoptim](http://www.kokkonen.net/tjko/projects.html)
 * [jpeg-recompress](https://github.com/danielgtaylor/jpeg-archive#jpeg-recompress)
@@ -152,6 +153,19 @@ cd pngcrush-$PNGCRUSH_VERSION
 make && cp -f pngcrush /usr/local/bin
 ```
 
+#### guetzli
+
+Replace `X.Y` with latest version number from https://github.com/google/guetzli/releases.
+
+```bash
+GUETZLI_VERSION=X.Y
+cd /tmp
+curl -L -o guetzli-$GUETZLI_VERSION.tar.gz https://github.com/google/guetzli/archive/v$GUETZLI_VERSION.tar.gz
+tar zxf guetzli-$GUETZLI_VERSION.tar.gz
+cd guetzli-$GUETZLI_VERSION
+make && cp -f bin/Release/guetzli /usr/local/bin
+```
+
 ### OS X: Macports
 
 ```bash
@@ -284,6 +298,10 @@ Worker can be disabled by passing `false` instead of options hash or by setting 
 * `:interlace` — Interlace: `true` - interlace on, `false` - interlace off, `nil` - as is in original image (defaults to running two instances, one with interlace off and one with on)
 * `:level` — Compression level: `1` - light and fast, `2` - normal, `3` - heavy (slower) *(defaults to `3`)*
 * `:careful` — Avoid bugs with some software *(defaults to `false`)*
+
+### guetzli:
+* `:allow_lossy` — Allow quality option *(defaults to `false`)*
+* `:quality` — JPEG quality `0`..`100`, ignored in default/lossless mode *(defaults to `100`)*
 
 ### jhead:
 Worker has no options

--- a/lib/image_optim.rb
+++ b/lib/image_optim.rb
@@ -12,7 +12,7 @@ require 'shellwords'
 %w[
   pngcrush pngout advpng optipng pngquant
   jhead jpegoptim jpegrecompress jpegtran
-  gifsicle
+  gifsicle guetzli
   svgo
 ].each do |worker|
   require "image_optim/worker/#{worker}"

--- a/lib/image_optim/bin_resolver/bin.rb
+++ b/lib/image_optim/bin_resolver/bin.rb
@@ -98,6 +98,8 @@ class ImageOptim
         when :jpegrescan
           # jpegrescan has no version so use first 8 characters of sha1 hex
           Digest::SHA1.file(path).hexdigest[0, 8] if path
+        when :guetzli
+          capture("#{escaped_path} -version 2> #{Path::NULL}")[/.*/]
         else
           fail "getting `#{name}` version is not defined"
         end

--- a/lib/image_optim/bin_resolver/bin.rb
+++ b/lib/image_optim/bin_resolver/bin.rb
@@ -99,7 +99,8 @@ class ImageOptim
           # jpegrescan has no version so use first 8 characters of sha1 hex
           Digest::SHA1.file(path).hexdigest[0, 8] if path
         when :guetzli
-          capture("#{escaped_path} -version 2> #{Path::NULL}")[/.*/]
+          # guetzli has no version so use first 8 characters of sha1 hex
+          Digest::SHA1.file(path).hexdigest[0, 8] if path
         else
           fail "getting `#{name}` version is not defined"
         end

--- a/lib/image_optim/config.rb
+++ b/lib/image_optim/config.rb
@@ -167,9 +167,11 @@ class ImageOptim
 
       case worker_options
       when Hash
-        worker_options
-      when true, nil
+        {:disable => false}.merge(worker_options)
+      when nil
         {}
+      when true
+        {:disable => false}
       when false
         {:disable => true}
       else

--- a/lib/image_optim/worker/class_methods.rb
+++ b/lib/image_optim/worker/class_methods.rb
@@ -77,12 +77,23 @@ class ImageOptim
         resolved.sort_by.with_index{ |worker, i| [worker.run_order, i] }
       end
 
+      # Indicate that the worker should not be used unless explicitly enabled
+      # with a `disabled: false` option passed to `ImageOptim.new` for it.
+      def disabled_by_default
+        false
+      end
+
     private
 
       def init_all(image_optim, &options_proc)
         klasses.map do |klass|
           options = options_proc[klass]
-          next if options[:disable]
+
+          if klass.disabled_by_default && options[:disable].nil?
+            options[:disable] = true
+          end
+
+          next if options.delete(:disable)
           if !options.key?(:allow_lossy) && klass.method_defined?(:allow_lossy)
             options[:allow_lossy] = image_optim.allow_lossy
           end

--- a/lib/image_optim/worker/guetzli.rb
+++ b/lib/image_optim/worker/guetzli.rb
@@ -1,0 +1,44 @@
+require 'image_optim/worker'
+require 'image_optim/option_helpers'
+
+class ImageOptim
+  class Worker
+    # https://github.com/google/guetzli/
+    class Guetzli < Worker
+      ALLOW_LOSSY_OPTION =
+        option(:allow_lossy, false, 'Allow quality option'){ |v| !!v }
+
+      QUALITY_OPTION =
+      option(:quality, 100, 'JPEG quality `0`..`100`, ignored in '\
+         'default/lossless mode') do |v, opt_def|
+        if allow_lossy
+          OptionHelpers.limit_with_range(v.to_i, 0..100)
+        else
+          if v != opt_def.default
+            warn "#{self.class.bin_sym} #{opt_def.name} #{v} ignored " \
+                 'in lossless mode'
+          end
+          opt_def.default
+        end
+      end
+
+      def image_formats
+        [:jpeg]
+      end
+
+      def run_order
+        quality < 100 ? -1 : 0
+      end
+
+      def optimize(src, dst)
+        src.copy(dst)
+        args = %W[
+          --quality #{quality}
+          #{src}
+          #{dst}
+        ]
+        execute(:guetzli, *args) && optimized?(src, dst)
+      end
+    end
+  end
+end

--- a/lib/image_optim/worker/guetzli.rb
+++ b/lib/image_optim/worker/guetzli.rb
@@ -23,7 +23,7 @@ class ImageOptim
       end
 
       def run_order
-        quality < 100 ? -1 : 0
+        -3
       end
 
       def optimize(src, dst)

--- a/lib/image_optim/worker/guetzli.rb
+++ b/lib/image_optim/worker/guetzli.rb
@@ -13,6 +13,11 @@ class ImageOptim
         super if options[:allow_lossy]
       end
 
+      # Disable this worker by default due to it being very memory intensive.
+      def self.disabled_by_default
+        true
+      end
+
       QUALITY_OPTION =
       option(:quality, 100, 'JPEG quality `0`..`100`') do |v, opt_def|
         OptionHelpers.limit_with_range(v.to_i, 0..100)

--- a/lib/image_optim/worker/guetzli.rb
+++ b/lib/image_optim/worker/guetzli.rb
@@ -6,20 +6,16 @@ class ImageOptim
     # https://github.com/google/guetzli/
     class Guetzli < Worker
       ALLOW_LOSSY_OPTION =
-        option(:allow_lossy, false, 'Allow quality option'){ |v| !!v }
+      option(:allow_lossy, false, 'Allow worker, it is always lossy'){ |v| !!v }
+
+      # Initialize only if allow_lossy
+      def self.init(image_optim, options = {})
+        super if options[:allow_lossy]
+      end
 
       QUALITY_OPTION =
-      option(:quality, 100, 'JPEG quality `0`..`100`, ignored in '\
-         'default/lossless mode') do |v, opt_def|
-        if allow_lossy
-          OptionHelpers.limit_with_range(v.to_i, 0..100)
-        else
-          if v != opt_def.default
-            warn "#{self.class.bin_sym} #{opt_def.name} #{v} ignored " \
-                 'in lossless mode'
-          end
-          opt_def.default
-        end
+      option(:quality, 100, 'JPEG quality `0`..`100`') do |v, opt_def|
+        OptionHelpers.limit_with_range(v.to_i, 0..100)
       end
 
       def image_formats

--- a/spec/image_optim/config_spec.rb
+++ b/spec/image_optim/config_spec.rb
@@ -111,12 +111,22 @@ describe ImageOptim::Config do
 
     it 'returns passed hash' do
       config = IOConfig.new(:abc => {:option => true})
-      expect(config.for_worker(Abc)).to eq(:option => true)
+      expect(config.for_worker(Abc)).to include(:option => true)
     end
 
     it 'returns {:disable => true} for false' do
       config = IOConfig.new(:abc => false)
       expect(config.for_worker(Abc)).to eq(:disable => true)
+    end
+
+    it 'returns {:disable => false} for true' do
+      config = IOConfig.new(:abc => true)
+      expect(config.for_worker(Abc)).to eq(:disable => false)
+    end
+
+    it 'includes {:disable => false} when passed a hash' do
+      config = IOConfig.new(:abc => {:option => true})
+      expect(config.for_worker(Abc)).to include(:disable => false)
     end
 
     it 'raises on unknown option' do

--- a/spec/image_optim/worker_spec.rb
+++ b/spec/image_optim/worker_spec.rb
@@ -126,7 +126,9 @@ describe ImageOptim::Worker do
     end
 
     def worker_class_doubles(workers)
-      workers.map{ |worker| class_double(Worker, :init => worker) }
+      workers.map do |worker|
+        class_double(Worker, :init => worker, :disabled_by_default => false)
+      end
     end
 
     let(:image_optim){ double(:allow_lossy => false) }


### PR DESCRIPTION
Hello,

This is my take at implementing support for [Guetzli](https://research.googleblog.com/2017/03/announcing-guetzli-new-open-source-jpeg.html).

At this time there are a few compatibility issues that come with it:

- [x] It has no support in the `image_optim_pack` yet.
- [x] It depends on [gflags](https://github.com/gflags/gflags/) which requires a version of CMake that is unavailable in Ubuntu 12.04 (Travis CI runs 12.04 by default). (Dependency removed upstream https://github.com/google/guetzli/pull/97)
- [x] It fails to link on OS X Yosemite. (But this has been fixed upstream https://github.com/google/guetzli/issues/41, https://github.com/google/guetzli/pull/55).
- [ ] I have not tested it at all on Windows.
- [ ] I have not tested it at all on *BSD.