### PR TITLE
Support lossy option on giflossy

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Show full bin search path in verbose output [@toy](https://github.com/toy)
+* Add support for lossy option for `giflossy` (`gifsicle` fork) [@dejan](https://github.com/dejan)
 
 ## v0.26.1 (2017-12-14)
 

--- a/README.markdown
+++ b/README.markdown
@@ -284,6 +284,8 @@ Worker can be disabled by passing `false` instead of options hash or by setting 
 * `:interlace` — Interlace: `true` - interlace on, `false` - interlace off, `nil` - as is in original image (defaults to running two instances, one with interlace off and one with on)
 * `:level` — Compression level: `1` - light and fast, `2` - normal, `3` - heavy (slower) *(defaults to `3`)*
 * `:careful` — Avoid bugs with some software *(defaults to `false`)*
+* `:allow_lossy` — Allow `:lossy` option (available only on giflossy, fork of gifsicle) *(defaults to `false`)*
+* `:lossy` — lossy compression level (requires giflossy). Value type is signed integer. Use low positive values for better quality or low negative values for extremly bad quality. Example values: `0` - no lossy compression, `20` - low level compression (low noise), `1000` - high level of compression (high noise), `-1` - max level of compression (max noise) *(defaults to `0`)*
 
 ### jhead:
 Worker has no options


### PR DESCRIPTION
Add support for `lossy` option on `giflossy`.

[giflossy](https://github.com/kornelski/giflossy) is a fork of gifsicle which support lossy compression.