### PR TITLE
Add skip-if-larger params for pngquant

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Add `--skip-if-larger` flag to pngquant worker. The pngquant worker already does this, but this will make it fail faster. [@iggant][https://github.com/iggant] [@oblakeerickson][https://github.com/oblakeerickson]
+
 ## v0.27.1 (2020-09-30)
 
 * Fixed atomic replacement for case when equal `File::Stat#dev` doesn't mean that file can be linked [#180](https://github.com/toy/image_optim/issues/180) [@toy](https://github.com/toy)

--- a/lib/image_optim/worker/pngquant.rb
+++ b/lib/image_optim/worker/pngquant.rb
@@ -55,6 +55,7 @@ class ImageOptim
           --quality=#{quality.begin}-#{quality.end}
           --speed=#{speed}
           --output=#{dst}
+          --skip-if-larger
           --force
           #{max_colors}
           --


### PR DESCRIPTION
The `pngquant` worker will not allow bigger files, but adding the
`--skip-if-larger` flag should make it fail faster. Added a changelog
entry.

This supersedes: https://github.com/toy/image_optim/pull/125 Sorry, I don't have push access to the original branch to not create another pr.

Co-authored-by: Blake Erickson <o.blakeerickson@gmail.com>