### PR TITLE
Add method option to jpeg-recompress for passing in comparison metrics

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Add `--skip-if-larger` flag to pngquant worker. The pngquant worker already does this, but this will make it fail faster. [#125](https://github.com/toy/image_optim/pull/125) [#181](https://github.com/toy/image_optim/pull/181) [@iggant][https://github.com/iggant] [@oblakeerickson][https://github.com/oblakeerickson]
+* Add `method` option for jpegrecompress, default to `ssim` [#103](https://github.com/toy/image_optim/pull/103) [@ramiroaraujo](https://github.com/ramiroaraujo) [@oblakeerickson](https://github.com/oblakeerickson)
 
 ## v0.27.1 (2020-09-30)
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Add `--skip-if-larger` flag to pngquant worker. The pngquant worker already does this, but this will make it fail faster. [#125](https://github.com/toy/image_optim/pull/125) [#181](https://github.com/toy/image_optim/pull/181) [@iggant][https://github.com/iggant] [@oblakeerickson][https://github.com/oblakeerickson]
-* Add `method` option for jpegrecompress, default to `ssim` [#103](https://github.com/toy/image_optim/pull/103) [@ramiroaraujo](https://github.com/ramiroaraujo) [@oblakeerickson](https://github.com/oblakeerickson)
+* Add `method` option for jpegrecompress, default to `ssim` [#102](https://github.com/toy/image_optim/issues/102) [#103](https://github.com/toy/image_optim/pull/103) [#182](https://github.com/toy/image_optim/pull/182) [@ramiroaraujo](https://github.com/ramiroaraujo) [@oblakeerickson](https://github.com/oblakeerickson)
 
 ## v0.27.1 (2020-09-30)
 

--- a/README.markdown
+++ b/README.markdown
@@ -316,6 +316,7 @@ Worker has no options
 ### jpegrecompress:
 * `:allow_lossy` — Allow worker, it is always lossy *(defaults to `false`)*
 * `:quality` — JPEG quality preset: `0` - low, `1` - medium, `2` - high, `3` - veryhigh *(defaults to `3`)*
+* `:method` — Comparison Metric: `mpe` - Mean pixel error, `ssim` - Structural similarity, `ms-ssim` - Multi-scale structural similarity (slow!), `smallfry` - Linear-weighted BBCQ-like (may be patented) *(defaults to ssim)*
 
 ### jpegtran:
 * `:copy_chunks` — Copy all chunks *(defaults to `false`)*

--- a/lib/image_optim/runner/option_parser.rb
+++ b/lib/image_optim/runner/option_parser.rb
@@ -202,6 +202,8 @@ ImageOptim::Runner::OptionParser::DEFINE = proc do |op, options|
         [Integer, 'N']
       when Array >= type
         [Array, 'a,b,c']
+      when String >= type
+        [String, 'S']
       when ImageOptim::NonNegativeIntegerRange == type
         [type, 'M-N']
       else

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -26,6 +26,19 @@ class ImageOptim
         OptionHelpers.limit_with_range(v.to_i, 0...QUALITY_NAMES.length)
       end
 
+      METHOD_OPTION =
+      option(:method, 'ssim', 'Comparison Metric: '\
+          '`mpe` - Mean pixel error, '\
+          '`ssim` - Structural similarity, '\
+          '`ms-ssim` - Multi-scale structural similarity (slow!), '\
+          '`smallfry` - Linear-weighted BBCQ-like (may be patented)') do |v, opt_def|
+        unless %w[mpe ssim ms-ssim smallfry].include? v
+          warn "Unknown method for jpegrecompress: #{v}"
+          opt_def.default
+        end
+        v
+      end
+
       def used_bins
         [:'jpeg-recompress']
       end
@@ -38,6 +51,7 @@ class ImageOptim
       def optimize(src, dst)
         args = %W[
           --quality #{QUALITY_NAMES[quality]}
+          --method #{method}
           --no-copy
           #{src}
           #{dst}

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -32,11 +32,12 @@ class ImageOptim
           '`ssim` - Structural similarity, '\
           '`ms-ssim` - Multi-scale structural similarity (slow!), '\
           '`smallfry` - Linear-weighted BBCQ-like (may be patented)') do |v, opt_def|
-        unless %w[mpe ssim ms-ssim smallfry].include? v
+        if !%w[mpe ssim ms-ssim smallfry].include? v
           warn "Unknown method for jpegrecompress: #{v}"
           opt_def.default
+        else
+          v
         end
-        v
       end
 
       def used_bins

--- a/spec/image_optim/worker/jpegrecompress_spec.rb
+++ b/spec/image_optim/worker/jpegrecompress_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'image_optim/worker/jpegrecompress'
+
+describe ImageOptim::Worker::Jpegrecompress do
+  describe 'method value' do
+    let(:subject){ described_class.new(ImageOptim.new, method).method }
+
+    context 'default' do
+      let(:method){ {} }
+
+      it{ is_expected.to eq('ssim') }
+    end
+
+    context 'uses default when invalid' do
+      let(:method){ {:method => 'invalid'} }
+
+      it 'warns and keeps default' do
+        expect_any_instance_of(described_class).
+          to receive(:warn).with('Unknown method for jpegrecompress: invalid')
+        is_expected.to eq('ssim')
+      end
+    end
+
+    context 'can use a valid option' do
+      let(:method){ {:method => 'smallfry'} }
+
+      it{ is_expected.to eq('smallfry') }
+    end
+  end
+end


### PR DESCRIPTION
added compression methods option for passing to jpeg-compress
added String type to option parser and changed Array to String y method option for jpegrecompress
updated changelog
warn when unknown jpegrecompress compression method is specified, and beter explanation for the methods
Made suggested edits

Supersedes: https://github.com/toy/image_optim/pull/103 Sorry for creating another PR, but I don't have write permission to the original branch.

Closes #102 

Co-authored-by: Blake Erickson <o.blakeerickson@gmail.com>