### PR TITLE
FEATURE: Add global and worker timeout option.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,7 +67,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
 
 Metrics/CyclomaticComplexity:
   Max: 11

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@
 
 * Add `--skip-if-larger` flag to pngquant worker. The pngquant worker already does this, but this will make it fail faster. [#125](https://github.com/toy/image_optim/pull/125) [#181](https://github.com/toy/image_optim/pull/181) [@iggant][https://github.com/iggant] [@oblakeerickson][https://github.com/oblakeerickson]
 * Add `method` option for jpegrecompress, default to `ssim` [#102](https://github.com/toy/image_optim/issues/102) [#103](https://github.com/toy/image_optim/pull/103) [#182](https://github.com/toy/image_optim/pull/182) [@ramiroaraujo](https://github.com/ramiroaraujo) [@oblakeerickson](https://github.com/oblakeerickson)
+* Add `timeout` option to ImageOptim [#21](https://github.com/toy/image_optim/issues/21) [@tgxworld](https://github.com/tgxworld) [@oblakeerickson](https://github.com/oblakeerickson)
 
 ## v0.27.1 (2020-09-30)
 

--- a/README.markdown
+++ b/README.markdown
@@ -291,6 +291,7 @@ optipng:
 * `:allow_lossy` — Allow lossy workers and optimizations *(defaults to `false`)*
 * `:cache_dir` — Configure cache directory
 * `:cache_worker_digests` - Also cache worker digests along with original file digest and worker options: updating workers invalidates cache
+* `:timeout` - Number of seconds before ImageOptim is timed out.
 
 Worker can be disabled by passing `false` instead of options hash or by setting option `:disable` to `true`.
 

--- a/lib/image_optim/config.rb
+++ b/lib/image_optim/config.rb
@@ -119,6 +119,11 @@ class ImageOptim
       end
     end
 
+    def timeout
+      timeout = get!(:timeout)
+      timeout ? timeout.to_f : nil
+    end
+
     # Verbose mode, converted to boolean
     def verbose
       !!get!(:verbose)

--- a/lib/image_optim/runner/option_parser.rb
+++ b/lib/image_optim/runner/option_parser.rb
@@ -182,6 +182,10 @@ ImageOptim::Runner::OptionParser::DEFINE = proc do |op, options|
     options[:allow_lossy] = allow_lossy
   end
 
+  op.on('--timeout N', Integer, 'Sets a timeout for optimization') do |timeout|
+    options[:timeout] = timeout
+  end
+
   op.separator nil
 
   ImageOptim::Worker.klasses.each_with_index do |klass, i|

--- a/lib/image_optim/worker.rb
+++ b/lib/image_optim/worker.rb
@@ -19,6 +19,8 @@ class ImageOptim
       alias_method :init, :new
     end
 
+    attr_accessor :pid
+
     # Configure (raises on extra options)
     def initialize(image_optim, options = {})
       unless image_optim.is_a?(ImageOptim)
@@ -26,6 +28,7 @@ class ImageOptim
       end
 
       @image_optim = image_optim
+      default_options
       parse_options(options)
       assert_no_unknown_options!(options)
     end
@@ -90,6 +93,17 @@ class ImageOptim
     end
 
   private
+
+    # Specify any options that should exist on every worker
+    def default_options
+      self.class.option('timeout', false, 'Specify a worker specific timeout') do |v|
+        if v && v.to_f > 0
+          v.to_f
+        else
+          false
+        end
+      end
+    end
 
     def parse_options(options)
       self.class.option_definitions.each do |option_definition|
@@ -157,7 +171,8 @@ class ImageOptim
           {:out => Path::NULL, :err => Path::NULL},
         ].flatten
       end
-      Cmd.run(*args)
+
+      Cmd.run(*args){ |pid| self.pid = pid }
     end
   end
 end

--- a/spec/image_optim/cmd_spec.rb
+++ b/spec/image_optim/cmd_spec.rb
@@ -17,13 +17,6 @@ describe ImageOptim::Cmd do
   end
 
   describe '.run' do
-    it 'calls system and returns result' do
-      status = double
-      expect(Cmd).to receive(:system).with('cmd', 'arg').and_return(status)
-      allow(Cmd).to receive(:check_status!)
-      expect(Cmd.run('cmd', 'arg')).to eq(status)
-    end
-
     it 'returns process success status' do
       expect(Cmd.run('sh -c "exit 0"')).to eq(true)
       expect($CHILD_STATUS.exitstatus).to eq(0)
@@ -33,6 +26,14 @@ describe ImageOptim::Cmd do
 
       expect(Cmd.run('sh -c "exit 66"')).to eq(false)
       expect($CHILD_STATUS.exitstatus).to eq(66)
+    end
+
+    it 'accepts a block that yields the pid' do
+      expect(
+        Cmd.run('sh -c "exit 66"') do |pid|
+          expect(pid.is_a?(Integer)).to eq(true)
+        end
+      ).to eq(false)
     end
 
     it 'raises SignalException if process terminates after signal' do

--- a/spec/image_optim/config_spec.rb
+++ b/spec/image_optim/config_spec.rb
@@ -237,4 +237,20 @@ describe ImageOptim::Config do
       expect(IOConfig.read_options(path)).to eq({})
     end
   end
+
+  describe '#timeout' do
+    before do
+      allow(IOConfig).to receive(:read_options).and_return({})
+    end
+
+    it 'is nil by default' do
+      config = IOConfig.new({})
+      expect(config.timeout).to eq(nil)
+    end
+
+    it 'converts value to a float' do
+      config = IOConfig.new(:timeout => '15.1')
+      expect(config.timeout).to eq(15.1)
+    end
+  end
 end

--- a/spec/image_optim/worker_spec.rb
+++ b/spec/image_optim/worker_spec.rb
@@ -31,7 +31,7 @@ describe ImageOptim::Worker do
 
       worker = worker_class.new(ImageOptim.new, :three => '...')
 
-      expect(worker.options).to eq(:one => 1, :two => 2, :three => '...')
+      expect(worker.options).to eq(:one => 1, :two => 2, :three => '...', :timeout => false)
     end
   end
 
@@ -74,7 +74,7 @@ describe ImageOptim::Worker do
 
       worker = DefOptim.new(ImageOptim.new, :three => '...')
 
-      expect(worker.inspect).to eq('#<DefOptim @one=1, @two=2, @three="...">')
+      expect(worker.inspect).to eq('#<DefOptim @one=1, @two=2, @three="...", @timeout=false>')
     end
   end
 
@@ -281,6 +281,36 @@ describe ImageOptim::Worker do
       expect(definition).to be_an(ImageOptim::OptionDefinition)
       expect(definition.name).to eq(:test)
       expect(definition.default).to eq(1)
+    end
+  end
+
+  describe 'worker timeout option' do
+    it 'exists on every worker by default' do
+      worker_class = Class.new(Worker)
+      worker = worker_class.new(ImageOptim.new)
+
+      expect(worker.timeout).to eq(false)
+    end
+
+    it 'only accepts numbers' do
+      worker_class = Class.new(Worker)
+      worker = worker_class.new(ImageOptim.new, :timeout => 'asdf')
+
+      expect(worker.timeout).to eq(false)
+    end
+
+    it 'converts to floats' do
+      worker_class = Class.new(Worker)
+      worker = worker_class.new(ImageOptim.new, :timeout => 9)
+
+      expect(worker.timeout).to eq(9.0)
+    end
+
+    it 'only accepts positive numbers' do
+      worker_class = Class.new(Worker)
+      worker = worker_class.new(ImageOptim.new, :timeout => -1)
+
+      expect(worker.timeout).to eq(false)
     end
   end
 end


### PR DESCRIPTION
This PR addresses the feedback what was originally given on PR #162 by
adding a default worker specific timeout option in addition to a global
timeout.

The original commit

https://github.com/discourse/image_optim/commit/8bf3c0e32f50cd2e3e23c0b5b936947994ff75e8

on PR #162 with just the global timeout has been in production since
2018-07-08 on Discourse instances using a forked version of this gem.

We would like to get this change merged in, so that we can get off of
the discourse specific fork and use the latest version of the
image_optim gem.

Co-authored-by: Blake Erickson <o.blakeerickson@gmail.com>