### PR TITLE
FEATURE: Timeout option for ImageOptim.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Add `timeout` option to restrict maximum time spent on every image [#21](https://github.com/toy/image_optim/issues/21) [#148](https://github.com/toy/image_optim/pull/148) [#149](https://github.com/toy/image_optim/pull/149) [#162](https://github.com/toy/image_optim/pull/162) [#184](https://github.com/toy/image_optim/pull/184) [#189](https://github.com/toy/image_optim/pull/189) [@tgxworld](https://github.com/tgxworld) [@oblakeerickson](https://github.com/oblakeerickson) [@toy](https://github.com/toy)
+
 ## v0.29.0 (2021-04-28)
 
 * Require at least ruby 1.9.3 [@toy](https://github.com/toy)

--- a/README.markdown
+++ b/README.markdown
@@ -291,6 +291,7 @@ optipng:
 * `:allow_lossy` — Allow lossy workers and optimizations *(defaults to `false`)*
 * `:cache_dir` — Configure cache directory
 * `:cache_worker_digests` - Also cache worker digests along with original file digest and worker options: updating workers invalidates cache
+* `:timeout` — Maximum time in seconds to spend on one image, note multithreading and cache *(defaults to unlimited)*
 
 Worker can be disabled by passing `false` instead of options hash or by setting option `:disable` to `true`.
 

--- a/lib/image_optim/cache.rb
+++ b/lib/image_optim/cache.rb
@@ -21,6 +21,11 @@ class ImageOptim
           "#{bin.name}[#{bin.digest}]"
         end.sort!.uniq.join(', ')]
       end]
+      @global_options = begin
+        options = {}
+        options[:timeout] = image_optim.timeout if image_optim.timeout
+        options.empty? ? '' : options.inspect
+      end
     end
 
     def fetch(original)
@@ -68,6 +73,7 @@ class ImageOptim
       digest = Digest::SHA1.file(path)
       digest.update options_by_format(format)
       digest.update bins_by_format(format) if @cache_worker_digests
+      digest.update @global_options
       s = digest.hexdigest
       "#{s[0..1]}/#{s[2..-1]}"
     end

--- a/lib/image_optim/cmd.rb
+++ b/lib/image_optim/cmd.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'image_optim/errors'
 require 'English'
 
 class ImageOptim
@@ -10,11 +11,30 @@ class ImageOptim
       # Return success status
       # Will raise SignalException if process was interrupted
       def run(*args)
-        success = system(*args)
+        if args.last.is_a?(Hash) && (timeout = args.last.delete(:timeout))
+          args.last[Gem.win_platform? ? :new_pgroup : :pgroup] = true
 
-        check_status!
+          pid = Process.spawn(*args)
 
-        success
+          waiter = Process.detach(pid)
+          if waiter.join(timeout)
+            status = waiter.value
+
+            check_status!(status)
+
+            status.success?
+          else
+            cleanup(pid, waiter)
+
+            fail Errors::TimeoutExceeded
+          end
+        else
+          success = system(*args)
+
+          check_status!
+
+          success
+        end
       end
 
       # Run using backtick
@@ -30,9 +50,7 @@ class ImageOptim
 
     private
 
-      def check_status!
-        status = $CHILD_STATUS
-
+      def check_status!(status = $CHILD_STATUS)
         return unless status.signaled?
 
         # jruby incorrectly returns true for `signaled?` if process exits with
@@ -45,6 +63,27 @@ class ImageOptim
         return if defined?(JRUBY_VERSION) && status.exitstatus == status.termsig
 
         fail SignalException, status.termsig
+      end
+
+      def cleanup(pid, waiter)
+        if Gem.win_platform?
+          kill('KILL', pid)
+        else
+          kill('-TERM', pid)
+
+          # Allow 10 seconds for the process to exit
+          waiter.join(10)
+
+          kill('-KILL', pid)
+        end
+
+        waiter.join
+      end
+
+      def kill(signal, pid)
+        Process.kill(signal, pid)
+      rescue Errno::ESRCH, Errno::EPERM
+        # expected
       end
     end
   end

--- a/lib/image_optim/config.rb
+++ b/lib/image_optim/config.rb
@@ -117,6 +117,14 @@ class ImageOptim
       end
     end
 
+    # Timeout in seconds for each image:
+    # * not set by default and for `nil`
+    # * otherwise converted to float
+    def timeout
+      timeout = get!(:timeout)
+      timeout ? timeout.to_f : nil
+    end
+
     # Verbose mode, converted to boolean
     def verbose
       !!get!(:verbose)

--- a/lib/image_optim/elapsed_time.rb
+++ b/lib/image_optim/elapsed_time.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ImageOptim
+  # Use Process.clock_gettime if available to get time more fitting to calculate elapsed time
+  module ElapsedTime
+    CLOCK_NAME = %w[
+      CLOCK_UPTIME_RAW
+      CLOCK_UPTIME
+      CLOCK_MONOTONIC_RAW
+      CLOCK_MONOTONIC
+      CLOCK_REALTIME
+    ].find{ |name| Process.const_defined?(name) }
+
+    CLOCK_ID = CLOCK_NAME && Process.const_get(CLOCK_NAME)
+
+  module_function
+
+    def now
+      if CLOCK_ID
+        Process.clock_gettime(CLOCK_ID)
+      else
+        Time.now.to_f
+      end
+    end
+  end
+end

--- a/lib/image_optim/errors.rb
+++ b/lib/image_optim/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ImageOptim
+  class Error < StandardError; end
+
+  module Errors
+    class TimeoutExceeded < Error; end
+  end
+end

--- a/lib/image_optim/runner/option_parser.rb
+++ b/lib/image_optim/runner/option_parser.rb
@@ -182,6 +182,10 @@ ImageOptim::Runner::OptionParser::DEFINE = proc do |op, options|
     options[:allow_lossy] = allow_lossy
   end
 
+  op.on('--timeout N', Float, 'Maximum time in seconds to spend on one image') do |timeout|
+    options[:timeout] = timeout
+  end
+
   op.separator nil
 
   ImageOptim::Worker.klasses.each_with_index do |klass, i|

--- a/lib/image_optim/timer.rb
+++ b/lib/image_optim/timer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'image_optim/elapsed_time'
+
+class ImageOptim
+  # Hold start time and timeout
+  class Timer
+    include ElapsedTime
+
+    def initialize(seconds)
+      @start = now
+      @seconds = seconds
+    end
+
+    def elapsed
+      now - @start
+    end
+
+    def left
+      @seconds - elapsed
+    end
+
+    alias_method :to_f, :left
+  end
+end

--- a/lib/image_optim/worker/advpng.rb
+++ b/lib/image_optim/worker/advpng.rb
@@ -21,7 +21,7 @@ class ImageOptim
         4
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         src.copy(dst)
         args = %W[
           --recompress
@@ -30,7 +30,7 @@ class ImageOptim
           --
           #{dst}
         ]
-        execute(:advpng, *args) && optimized?(src, dst)
+        execute(:advpng, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/gifsicle.rb
+++ b/lib/image_optim/worker/gifsicle.rb
@@ -37,7 +37,7 @@ class ImageOptim
       CAREFUL_OPTION =
       option(:careful, false, 'Avoid bugs with some software'){ |v| !!v }
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         args = %W[
           --output=#{dst}
           --no-comments
@@ -58,7 +58,7 @@ class ImageOptim
         end
         args.unshift '--careful' if careful
         args.unshift "--optimize=#{level}" if level
-        execute(:gifsicle, *args) && optimized?(src, dst)
+        execute(:gifsicle, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/jhead.rb
+++ b/lib/image_optim/worker/jhead.rb
@@ -25,7 +25,7 @@ class ImageOptim
         [:jhead, :jpegtran]
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         return false unless oriented?(src)
 
         src.copy(dst)
@@ -34,7 +34,7 @@ class ImageOptim
           #{dst}
         ]
         resolve_bin!(:jpegtran)
-        execute(:jhead, *args) && dst.size?
+        execute(:jhead, args, options) && dst.size?
       end
 
     private

--- a/lib/image_optim/worker/jpegoptim.rb
+++ b/lib/image_optim/worker/jpegoptim.rb
@@ -47,7 +47,7 @@ class ImageOptim
         max_quality < 100 ? -1 : 0
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         src.copy(dst)
         args = %W[
           --quiet
@@ -58,7 +58,7 @@ class ImageOptim
           args.unshift "--strip-#{strip_marker}"
         end
         args.unshift "--max=#{max_quality}" if max_quality < 100
-        execute(:jpegoptim, *args) && optimized?(src, dst)
+        execute(:jpegoptim, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/jpegrecompress.rb
+++ b/lib/image_optim/worker/jpegrecompress.rb
@@ -49,7 +49,7 @@ class ImageOptim
         -5
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         args = %W[
           --quality #{QUALITY_NAMES[quality]}
           --method #{method}
@@ -57,7 +57,7 @@ class ImageOptim
           #{src}
           #{dst}
         ]
-        execute(:'jpeg-recompress', *args) && optimized?(src, dst)
+        execute(:'jpeg-recompress', args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/jpegtran.rb
+++ b/lib/image_optim/worker/jpegtran.rb
@@ -23,7 +23,7 @@ class ImageOptim
         jpegrescan ? [:jpegtran, :jpegrescan] : [:jpegtran]
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         if jpegrescan
           args = %W[
             #{src}
@@ -31,7 +31,7 @@ class ImageOptim
           ]
           args.unshift '-s' unless copy_chunks
           resolve_bin!(:jpegtran)
-          execute(:jpegrescan, *args) && optimized?(src, dst)
+          execute(:jpegrescan, args, options) && optimized?(src, dst)
         else
           args = %W[
             -optimize
@@ -40,7 +40,7 @@ class ImageOptim
           ]
           args.unshift '-copy', (copy_chunks ? 'all' : 'none')
           args.unshift '-progressive' if progressive
-          execute(:jpegtran, *args) && optimized?(src, dst)
+          execute(:jpegtran, args, options) && optimized?(src, dst)
         end
       end
     end

--- a/lib/image_optim/worker/optipng.rb
+++ b/lib/image_optim/worker/optipng.rb
@@ -30,7 +30,7 @@ class ImageOptim
         -4
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         src.copy(dst)
         args = %W[
           -o #{level}
@@ -42,7 +42,7 @@ class ImageOptim
         if strip && resolve_bin!(:optipng).version >= '0.7'
           args.unshift '-strip', 'all'
         end
-        execute(:optipng, *args) && optimized?(src, dst)
+        execute(:optipng, args, options) && optimized?(src, dst)
       end
 
       def optimized?(src, dst)

--- a/lib/image_optim/worker/pngcrush.rb
+++ b/lib/image_optim/worker/pngcrush.rb
@@ -28,7 +28,7 @@ class ImageOptim
         -6
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         flags = %w[
           -reduce
           -cc
@@ -49,7 +49,7 @@ class ImageOptim
           #{dst}
         ]
 
-        execute(:pngcrush, *args) && optimized?(src, dst)
+        execute(:pngcrush, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/pngout.rb
+++ b/lib/image_optim/worker/pngout.rb
@@ -24,7 +24,7 @@ class ImageOptim
         2
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         args = %W[
           -k#{copy_chunks ? 1 : 0}
           -s#{strategy}
@@ -33,7 +33,7 @@ class ImageOptim
           #{src}
           #{dst}
         ]
-        execute(:pngout, *args) && optimized?(src, dst)
+        execute(:pngout, args, options) && optimized?(src, dst)
       rescue SignalException => e
         raise unless Signal.list.key(e.signo) == 'SEGV'
         raise unless resolve_bin!(:pngout).version <= '20150920'

--- a/lib/image_optim/worker/pngquant.rb
+++ b/lib/image_optim/worker/pngquant.rb
@@ -50,7 +50,7 @@ class ImageOptim
         -2
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         args = %W[
           --quality=#{quality.begin}-#{quality.end}
           --speed=#{speed}
@@ -61,7 +61,7 @@ class ImageOptim
           --
           #{src}
         ]
-        execute(:pngquant, *args) && optimized?(src, dst)
+        execute(:pngquant, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/lib/image_optim/worker/svgo.rb
+++ b/lib/image_optim/worker/svgo.rb
@@ -16,7 +16,7 @@ class ImageOptim
         Array(v).map(&:to_s)
       end
 
-      def optimize(src, dst)
+      def optimize(src, dst, options = {})
         args = %W[
           --input #{src}
           --output #{dst}
@@ -27,7 +27,7 @@ class ImageOptim
         enable_plugins.each do |plugin_name|
           args.unshift "--enable=#{plugin_name}"
         end
-        execute(:svgo, *args) && optimized?(src, dst)
+        execute(:svgo, args, options) && optimized?(src, dst)
       end
     end
   end

--- a/spec/image_optim/cache_spec.rb
+++ b/spec/image_optim/cache_spec.rb
@@ -45,7 +45,7 @@ describe ImageOptim::Cache do
 
   context 'when cache is disabled (default)' do
     let(:image_optim) do
-      double(:image_optim, :cache_dir => nil, :cache_worker_digests => false)
+      double(:image_optim, :cache_dir => nil, :cache_worker_digests => false, :timeout => nil)
     end
     let(:cache){ Cache.new(image_optim, double) }
 
@@ -122,7 +122,7 @@ describe ImageOptim::Cache do
   context 'when cache is enabled (without worker digests)' do
     let(:image_optim) do
       double(:image_optim,
-             :cache_dir => cache_dir, :cache_worker_digests => false)
+             :cache_dir => cache_dir, :cache_worker_digests => false, :timeout => nil)
     end
     let(:cache) do
       cache = Cache.new(image_optim, {})
@@ -145,7 +145,7 @@ describe ImageOptim::Cache do
     let(:image_optim) do
       double(:image_optim,
              :cache_dir => cache_dir,
-             :cache_worker_digests => true)
+             :cache_worker_digests => true, :timeout => nil)
     end
     let(:cache) do
       cache = Cache.new(image_optim, {})

--- a/spec/image_optim/cmd_spec.rb
+++ b/spec/image_optim/cmd_spec.rb
@@ -41,6 +41,65 @@ describe ImageOptim::Cmd do
         Cmd.run('kill -s INT $$')
       end
     end
+
+    context 'with timeout' do
+      it 'returns process success status' do
+        expect(Cmd.run('sh -c "exit 0"', :timeout => 1)).to eq(true)
+
+        expect(Cmd.run('sh -c "exit 1"', :timeout => 1)).to eq(false)
+
+        expect(Cmd.run('sh -c "exit 66"', :timeout => 1)).to eq(false)
+      end
+
+      it 'raises SignalException if process terminates after signal' do
+        skip 'signals are not supported' unless signals_supported?
+        expect_int_exception do
+          Cmd.run('kill -s INT $$', :timeout => 1)
+        end
+      end
+
+      it 'raises TimeoutExceeded if process does not exit until timeout' do
+        expect do
+          Cmd.run('sleep 10', :timeout => 0)
+        end.to raise_error(ImageOptim::Errors::TimeoutExceeded)
+      end
+
+      it 'does not leave zombie threads' do
+        expect do
+          begin
+            Cmd.run('sleep 10', :timeout => 0)
+          rescue ImageOptim::Errors::TimeoutExceeded
+            # noop
+          end
+        end.not_to change{ Thread.list }
+      end
+
+      it 'receives TERM' do
+        skip 'signals are not supported' unless signals_supported?
+        waiter = double
+        allow(Process).to receive(:detach).once{ |pid| @pid = pid; waiter }
+        allow(waiter).to receive(:join){ sleep 0.1; nil }
+
+        expect do
+          Cmd.run('sleep 5', :timeout => 0.1)
+        end.to raise_error(ImageOptim::Errors::TimeoutExceeded)
+
+        expect(Process.wait2(@pid).last.termsig).to eq(Signal.list['TERM'])
+      end
+
+      it 'receives KILL if it does not react on TERM' do
+        skip 'signals are not supported' unless signals_supported?
+        waiter = double
+        allow(Process).to receive(:detach).once{ |pid| @pid = pid; waiter }
+        allow(waiter).to receive(:join){ sleep 0.1; nil }
+
+        expect do
+          Cmd.run('trap "" TERM; sleep 5', :timeout => 0.1)
+        end.to raise_error(ImageOptim::Errors::TimeoutExceeded)
+
+        expect(Process.wait2(@pid).last.termsig).to eq(Signal.list['KILL'])
+      end
+    end
   end
 
   describe '.capture' do

--- a/spec/image_optim/config_spec.rb
+++ b/spec/image_optim/config_spec.rb
@@ -69,6 +69,22 @@ describe ImageOptim::Config do
     end
   end
 
+  describe '#timeout' do
+    before do
+      allow(IOConfig).to receive(:read_options).and_return({})
+    end
+
+    it 'is nil by default' do
+      config = IOConfig.new({})
+      expect(config.timeout).to eq(nil)
+    end
+
+    it 'converts value to a float' do
+      config = IOConfig.new(:timeout => '15.1')
+      expect(config.timeout).to eq(15.1)
+    end
+  end
+
   describe '#cache_dir' do
     before do
       allow(IOConfig).to receive(:read_options).and_return({})

--- a/spec/image_optim/elapsed_time_spec.rb
+++ b/spec/image_optim/elapsed_time_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'image_optim/elapsed_time'
+
+describe ImageOptim::ElapsedTime do
+  let(:timeout){ 0.01 }
+
+  describe '.now' do
+    it 'returns incrementing value' do
+      expect{ sleep timeout }.to change{ described_class.now }.by_at_least(timeout)
+    end
+  end
+end

--- a/spec/image_optim/timer_spec.rb
+++ b/spec/image_optim/timer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'image_optim/timer'
+
+describe ImageOptim::Timer do
+  let!(:timer){ described_class.new(1) }
+
+  describe '#elapsed' do
+    it 'returns elapsed time' do
+      sleep 0.01
+
+      expect(timer.elapsed).to be >= 0.01
+    end
+  end
+
+  describe '#left' do
+    it 'returns time left' do
+      sleep 0.01
+
+      expect(timer.left).to be <= 0.99
+    end
+  end
+
+  describe '#to_f' do
+    it 'returns time left' do
+      sleep 0.01
+
+      expect(timer.to_f).to be <= 0.99
+    end
+  end
+end


### PR DESCRIPTION
I'm re-opening the original PR #162 and replacing PR #184 (sorry for multiple
PRs).

The original commit

discourse@8bf3c0e

on PR #162 with just the global timeout has been in production since
2018-07-08 on Discourse instances using a forked version of this gem.

We would like to get this change merged in, so that we can get off of
the discourse specific fork and use the latest version of the
image_optim gem.

---

This commit only adds a global timeout.

I'm re-submitting this pr because I think we should first merge in just this change for a global timeout and if need be in the future we can always add per-worker timeouts.

The global timeout is optional though so any existing users won't be affected at all by this change and they can opt in to use if they like.

The global timeout also works from the CLI:

```
image_optim --timeout 30 *.png
optimizing: ...... (elapsed: 30s)
ImageOptim::TimeoutExceeded
```

The other reason why I'm re-submitting this PR as just a global-timeout and not adding the per-worker timeouts is that when I originally started working on the worker-timeouts I didn't realize that image_optim was using the in_threads gem and then we were spawning even more threads to add a timeout for each worker which could result in deadlocks. To go about adding per-worker timeouts it might be good to add the functionality to in_threads directly instead of inside of image_optim. Either way I think my original approach to adding per-worker timeouts was flawed and we should come up with a better way of adding them if we end up going that route in the future.

Co-authored-by: Blake Erickson <o.blakeerickson@gmail.com>