### PR TITLE
Add support for use as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: image_optim
+  name: image_optim
+  entry: image_optim
+  language: ruby
+  types:
+  - image
+  args: []
+  additional_dependencies:
+  - image_optim_pack

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Add support for use as [pre-commit](https://pre-commit.com/) hook [#192](https://github.com/toy/image_optim/pull/192) [@proinsias](https://github.com/proinsias)
 * Fix `Path#copy_metadata` by rescuing also `Errno::EACCES` as it is done in `fileutils` [#187](https://github.com/toy/image_optim/issues/187) [@toy](https://github.com/toy)
 * More precise regular expression for capturing svgo version [@toy](https://github.com/toy)
 


### PR DESCRIPTION
* Adds configuration files needed for `image_optim` to be used as [pre-commit.com](https://pre-commit.com) hook.
* Also adds GitHub Action to regularly run [`pre-commit autoupdate`](https://pre-commit.com/#pre-commit-autoupdate) and create a pull request to update hook versions if needed.