### PR TITLE
Fix: TypeError: can't convert ImageOptim::Timer into Float

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,8 @@
 
 * Add support for Oxipng [#167](https://github.com/toy/image_optim/issues/167) [#190](https://github.com/toy/image_optim/pull/190) [@oblakeerickson](https://github.com/oblakeerickson)
 
+* Fix `TypeError: can't convert ImageOptim::Timer into Float` with Ruby 3 [#194](https://github.com/toy/image_optim/pull/194) [@yahonda](https://github.com/yahonda)
+
 ## v0.30.0 (2021-05-11)
 
 * Add `timeout` option to restrict maximum time spent on every image [#21](https://github.com/toy/image_optim/issues/21) [#148](https://github.com/toy/image_optim/pull/148) [#149](https://github.com/toy/image_optim/pull/149) [#162](https://github.com/toy/image_optim/pull/162) [#184](https://github.com/toy/image_optim/pull/184) [#189](https://github.com/toy/image_optim/pull/189) [@tgxworld](https://github.com/tgxworld) [@oblakeerickson](https://github.com/oblakeerickson) [@toy](https://github.com/toy)

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,7 +3,6 @@
 ## unreleased
 
 * Add support for Oxipng [#167](https://github.com/toy/image_optim/issues/167) [#190](https://github.com/toy/image_optim/pull/190) [@oblakeerickson](https://github.com/oblakeerickson)
-
 * Fix `TypeError: can't convert ImageOptim::Timer into Float` with Ruby 3 [#194](https://github.com/toy/image_optim/pull/194) [@yahonda](https://github.com/yahonda)
 
 ## v0.30.0 (2021-05-11)

--- a/lib/image_optim/cmd.rb
+++ b/lib/image_optim/cmd.rb
@@ -17,7 +17,7 @@ class ImageOptim
           pid = Process.spawn(*args)
 
           waiter = Process.detach(pid)
-          if waiter.join(timeout)
+          if waiter.join(timeout.to_f)
             status = waiter.value
 
             check_status!(status)

--- a/spec/image_optim/cmd_spec.rb
+++ b/spec/image_optim/cmd_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'image_optim/cmd'
+require 'image_optim/timer'
 
 describe ImageOptim::Cmd do
   before do
@@ -46,6 +47,11 @@ describe ImageOptim::Cmd do
         expect(Cmd.run('sh -c "exit 1"', timeout: 1)).to eq(false)
 
         expect(Cmd.run('sh -c "exit 66"', timeout: 1)).to eq(false)
+      end
+
+      it 'returns process success status when timeout is instance of ImageOptim::Timer' do
+        timeout = ImageOptim::Timer.new(1.0)
+        expect(Cmd.run('sh -c "exit 0"', timeout: timeout)).to eq(true)
       end
 
       it 'raises SignalException if process terminates after signal', skip: SkipConditions[:signals_support] do


### PR DESCRIPTION
This pull request addresses `TypeError: can't convert ImageOptim::Timer into Float`
when the timeout is an instance of `ImageOptim::Timer` with Ruby 3.0.2.

Refer to the original issue at Discourse https://meta.discourse.org/t/optimizedimage-specs-are-failing-with-ruby-3-0-2/204930

### Current behavior

* Reverting this code from this pull request to see how it fails.
```ruby
$ git diff
diff --git a/lib/image_optim/cmd.rb b/lib/image_optim/cmd.rb
index 4957f8d..ea00a28 100644
--- a/lib/image_optim/cmd.rb
+++ b/lib/image_optim/cmd.rb
@@ -17,7 +17,7 @@ class ImageOptim
           pid = Process.spawn(*args)

           waiter = Process.detach(pid)
-          if waiter.join(timeout.to_f)
+          if waiter.join(timeout)
             status = waiter.value

             check_status!(status)
$
```

* Ruby 3.0.2 raises `TypeError`
* 
```ruby
$ ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]
$ bundle exec rspec ./spec/image_optim/cmd_spec.rb:52
Run options: include {:locations=>{"./spec/image_optim/cmd_spec.rb"=>[52]}}

Randomized with seed 32230
F

Failures:

  1) ImageOptim::Cmd.run with timeout returns process success status when timeout is instance of ImageOptim::Timer
     Failure/Error: if waiter.join(timeout)

     TypeError:
       can't convert ImageOptim::Timer into Float
     # ./lib/image_optim/cmd.rb:20:in `join'
     # ./lib/image_optim/cmd.rb:20:in `run'
     # ./spec/image_optim/cmd_spec.rb:54:in `block (4 levels) in <top (required)>'

Finished in 0.0023 seconds (files took 0.09478 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/image_optim/cmd_spec.rb:52 # ImageOptim::Cmd.run with timeout returns process success status when timeout is instance of ImageOptim::Timer

Randomized with seed 32230

$
```

* Ruby 2.7.4 works fine

```ruby
$ ruby -v
ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-linux]
yahonda@myryzen:~/src/github.com/toy/image_optim$ bundle exec rspec ./spec/image_optim/cmd_spec.rb:52
Run options: include {:locations=>{"./spec/image_optim/cmd_spec.rb"=>[52]}}

Randomized with seed 21473
.

Finished in 0.00287 seconds (files took 0.09183 seconds to load)
1 example, 0 failures

Randomized with seed 21473

$
```