### PR TITLE
Support newer versions of psych/newer rubies

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Support Psych4/Ruby 3.1 changes to use safe_yaml methods by default [#203](https://github.com/toy/image_optim/issues/203) [#204](https://github.com/toy/image_optim/pull/204) [@oscillot](https://github.com/oscillot) [@toy](https://github.com/toy)
+
 ## v0.31.2 (2022-11-27)
 
 * Support jruby 9.4 [@toy](https://github.com/toy)

--- a/lib/image_optim/config.rb
+++ b/lib/image_optim/config.rb
@@ -33,7 +33,7 @@ class ImageOptim
         end
         return {} unless File.size?(full_path)
 
-        config = YAML.load_file(full_path)
+        config = load_yaml_file(full_path)
         unless config.is_a?(Hash)
           fail "expected hash, got #{config.inspect}"
         end
@@ -42,6 +42,14 @@ class ImageOptim
       rescue => e
         warn "exception when reading #{full_path}: #{e}"
         {}
+      end
+
+      def load_yaml_file(path)
+        if YAML.respond_to?(:safe_load_file)
+          YAML.safe_load_file(path, permitted_classes: [Range])
+        else
+          YAML.load_file(path)
+        end
       end
     end
 

--- a/spec/files/config_with_range.yaml
+++ b/spec/files/config_with_range.yaml
@@ -1,0 +1,3 @@
+range: !ruby/range 80..99
+number: 3
+string: foo


### PR DESCRIPTION
This change addresses issue [#203](https://github.com/toy/image_optim/issues/203) where using a `!ruby Range` value in the config yaml would cause an error and fail to load the config. This issue is due to a breaking change in psych at version 4. This change checks what version of psych we are working with and returns the correct arguments in the correct format for loading the config file.

It also adds enough flexibility that if there is another breaking change in the future it should be simple enough to add another strategy and this should work correctly even if they bring their own version of psych to use.

Testing this was a bit challenging. I was able to test it on the latest version of each ruby ruby 2.3.x-3.1.x in rspec and by running the reproduction code in the issue, however I wasn't able to test ruby 2.2 or 2.1 so I'm leaving that to the github action to tell me how I did.

In addition to the specs that I added, I modified some specs that did message expectations against the `YAML.load_file` method, adding `any_args` so that the expectation works correctly across all of the variations of the `load_file` call, since `any_args` conceptually includes `no_args`.

@toy we briefly spoke about using `respond_to?` but I found this clearer and more explicit, though this is your project so let me know if you disagree would like me to pursue the other route