### PR TITLE
Add support for svgo 2.x and 3.x

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,7 @@
 * Added --benchmark, to compare performance of each tool [#217](https://github.com/toy/image_optim/issues/217) [#218](https://github.com/toy/image_optim/pull/218) [@gurgeous](https://github.com/gurgeous)
 * Don't require presence of `git` in gemspec [@toy](https://github.com/toy)
 * Add a basic check for names of enabled and disabled svgo plugins [@toy](https://github.com/toy)
+* Add support for enabling/disabling plugins in svgo 2.x, 3.x, 4.x [#191](https://github.com/toy/image_optim/issues/191) [#224](https://github.com/toy/image_optim/pull/224) [@tomhughes](https://github.com/tomhughes)
 
 ## v0.31.4 (2024-11-19)
 

--- a/lib/image_optim/worker/svgo.rb
+++ b/lib/image_optim/worker/svgo.rb
@@ -2,6 +2,7 @@
 
 require 'image_optim/option_helpers'
 require 'image_optim/worker'
+require 'fspath'
 
 class ImageOptim
   class Worker
@@ -42,11 +43,18 @@ class ImageOptim
           --input #{src}
           --output #{dst}
         ]
-        disable_plugins.each do |plugin_name|
-          args.unshift "--disable=#{plugin_name}"
-        end
-        enable_plugins.each do |plugin_name|
-          args.unshift "--enable=#{plugin_name}"
+        if resolve_bin!(:svgo).version >= '2.0.0'
+          unless disable_plugins.empty? && enable_plugins.empty?
+            config_file = plugins_config_file
+            args.unshift "--config=#{config_file.path}"
+          end
+        else
+          disable_plugins.each do |plugin_name|
+            args.unshift "--disable=#{plugin_name}"
+          end
+          enable_plugins.each do |plugin_name|
+            args.unshift "--enable=#{plugin_name}"
+          end
         end
         args.unshift "--precision=#{precision}" if allow_lossy
         execute(:svgo, args, options) && optimized?(src, dst)
@@ -61,6 +69,29 @@ class ImageOptim
           else
             warn "Doesn't look like svgo plugin name: #{name}"
           end
+        end
+      end
+
+      def plugins_config_file
+        @plugins_config_file ||= FSPath.temp_file(%w[image_optim .js]).tap do |config_file|
+          config_file.puts 'export default {'
+          config_file.puts '  plugins: ['
+          config_file.puts '    {'
+          config_file.puts '      name: \'preset-default\','
+          config_file.puts '      params: {'
+          config_file.puts '        overrides: {'
+          disable_plugins.each do |plugin_name|
+            config_file.puts "          #{plugin_name}: false,"
+          end
+          config_file.puts '        }'
+          config_file.puts '      }'
+          config_file.puts '    },'
+          enable_plugins.each do |plugin_name|
+            config_file.puts "  '#{plugin_name}',"
+          end
+          config_file.puts '  ]'
+          config_file.puts '};'
+          config_file.close
         end
       end
     end


### PR DESCRIPTION
This resolves #191 by generating a configuration file for svgo if the version is 2.x or higher.